### PR TITLE
Bugfix for #14

### DIFF
--- a/resolvedvelocities/plot/summary_plots.py
+++ b/resolvedvelocities/plot/summary_plots.py
@@ -75,7 +75,7 @@ def plot_components(utime, mlat, mlon, vector, covariance, param='V', titles=Non
                 else:
                     ax.set_yticklabels([])
 
-                
+
                 ax.set_title(titles[i][j])
                 ax.tick_params(labelsize=8)
 
@@ -122,7 +122,7 @@ def plot_magnitude(utime, mlat, mlon, vmag, dvmag, vdir, dvdir, chi2, param='V',
         dvmag = dvmag*1000.
 
     # pad time gaps
-    utime, [vmag, dvmag, vdir, dvdir] = timegaps(utime, [vmag, dvmag, vdir, dvdir])
+    utime, [vmag, dvmag, vdir, dvdir, chi2] = timegaps(utime, [vmag, dvmag, vdir, dvdir, chi2])
 
     # get x-axis (time) tick locations and labels
     time, xticks, xlims = get_time_ticks(utime)


### PR DESCRIPTION
This fixes a bug where the plotting routine filled data gaps in the `vmag`, `dvmag`, `vdir`, and `dvdir` arrays with nans, but not the `chi2` array.  Although 'chi2' isn't plotted, it is used along with the relative error to filter points that shouldn't be plotted, which produces a broadcasting error if all arrays are not the same shape.  This should resolve #14.