### PR TITLE
[BUG]: setup requirements cleared accidentally for conda

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ numpy >= 1.16
 matplotlib >=2.2.4
 tables >= 3.3.0
 scipy >=1.2
+pymap3d
 apexpy

--- a/setup.py
+++ b/setup.py
@@ -20,17 +20,6 @@ with open(REQSFILE, 'r') as f:
     REQUIREMENTS = f.readlines()
 REQUIREMENTS = '\n'.join(REQUIREMENTS)
 
-# Do some nice things to help users install on conda.
-if sys.version_info[:2] < (3, 0):
-    EXCEPTION = OSError
-else:
-    EXCEPTION = subprocess.builtins.FileNotFoundError
-try:
-    subprocess.call(['conda', 'install', ' '.join(REQUIREMENTS)])
-    REQUIREMENTS = []
-except EXCEPTION:
-    pass
-
 # Get the readme text
 README = os.path.join(here, 'README.rst')
 with open(README, 'r') as f:


### PR DESCRIPTION
The `setup.py` file accidentally (via copy paste error?) included some code to clear the requirements if installing on conda.

This PR fixes that (see: #12).